### PR TITLE
Support bootstrap access by IP over HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,18 @@ Flow:
 - frontend раздаётся как статический сайт из контейнера
 - Caddy проксирует `/api/*` на backend и остальное на frontend
 - деплой идёт через `infra/docker/docker-compose.prod.yml`
+
+## Bootstrap по IP vs нормальный домен
+
+Для live bootstrap без домена используем plain HTTP:
+- `APP_DOMAIN=65.109.3.45`
+- `CADDY_SITE_ADDRESS=http://65.109.3.45`
+
+Для нормального production-домена оставляем обычный host, чтобы Caddy вёл себя как TLS entrypoint:
+- `APP_DOMAIN=nutrition.example.com`
+- `CADDY_SITE_ADDRESS=nutrition.example.com`
+
+Идея простая:
+- `APP_DOMAIN` остаётся значением host/IP для smoke checks и документации
+- `CADDY_SITE_ADDRESS` управляет тем, как именно Caddy открывает сайт
+- префикс `http://` нужен только для временного bootstrap по IP/host без TLS

--- a/docs/GITHUB_SETUP.md
+++ b/docs/GITHUB_SETUP.md
@@ -61,8 +61,12 @@ cd nutrition-app-v2
 - `SSH_KNOWN_HOSTS` — предпочтительный pinned host key; если не задан, workflow делает `ssh-keyscan` во время запуска
 
 Не нужно класть в GitHub secrets production `.env`, если сервер уже хранит runtime-конфиг локально.
-`APP_DOMAIN` должен жить в `/opt/nutrition-app-v2/.env` на сервере, потому что он нужен и Caddy, и post-deploy smoke check.
-Если переменная отсутствует или пуста, compose теперь подставит `localhost`, а production Caddyfile имеет такой же fallback для прямой валидации. Это нужно только для того, чтобы Caddy не падал на этапе парсинга; корректным production значением это не считается.
+`APP_DOMAIN` должен жить в `/opt/nutrition-app-v2/.env` на сервере, потому что он нужен для post-deploy smoke check.
+`CADDY_SITE_ADDRESS` тоже должен жить там же, потому что именно он задаёт Caddy site label:
+- для bootstrap по IP/HTTP: `CADDY_SITE_ADDRESS=http://65.109.3.45`
+- для нормального домена/TLS: `CADDY_SITE_ADDRESS=nutrition.example.com`
+
+Если переменные отсутствуют или пусты, compose теперь подставит `localhost`, а production Caddyfile имеет такой же fallback для прямой валидации. Это нужно только для того, чтобы Caddy не падал на этапе парсинга; корректным live значением это не считается.
 
 ## 5. Server-side expectations
 
@@ -76,7 +80,8 @@ Environment file:
 - у SSH user есть доступ к `/opt/nutrition-app-v2`
 - у SSH user есть право запускать `docker compose` без интерактивного sudo
 - на сервере установлен Docker + Compose plugin
-- в `/opt/nutrition-app-v2/.env` есть рабочий `APP_DOMAIN` (домен или временный IP/host для bootstrap)
+- в `/opt/nutrition-app-v2/.env` есть рабочие `APP_DOMAIN` и `CADDY_SITE_ADDRESS`
+- для IP bootstrap `CADDY_SITE_ADDRESS` должен быть со схемой `http://...`, иначе Caddy снова включит auto-HTTPS-поведение
 
 Deploy command, который выполняет workflow:
 

--- a/docs/LIVE_RUNBOOK.md
+++ b/docs/LIVE_RUNBOOK.md
@@ -32,17 +32,31 @@
 Создать файл:
 - `/opt/nutrition-app-v2/.env`
 
-Минимальный стартовый пример:
+Минимальный стартовый пример для нормального домена/TLS:
 
 ```env
 POSTGRES_DB=nutrition_app
 POSTGRES_USER=nutrition
 POSTGRES_PASSWORD=change-me-now
 APP_DOMAIN=example.com
+CADDY_SITE_ADDRESS=example.com
 ```
 
-Если используется временный домен/поддомен — подставить его в `APP_DOMAIN`.
-Если live DNS ещё не готов, допустим временный IP/host для bootstrap; главное, чтобы `APP_DOMAIN` не оставался пустым.
+Bootstrap-вариант без домена, когда приложение нужно открыть с другой машины по IP через plain HTTP:
+
+```env
+POSTGRES_DB=nutrition_app
+POSTGRES_USER=nutrition
+POSTGRES_PASSWORD=change-me-now
+APP_DOMAIN=65.109.3.45
+CADDY_SITE_ADDRESS=http://65.109.3.45
+```
+
+Правило такое:
+- `APP_DOMAIN` — host/IP для smoke checks и явного значения хоста
+- `CADDY_SITE_ADDRESS` — реальный Caddy site label
+- если нужен временный bootstrap без TLS, `CADDY_SITE_ADDRESS` должен начинаться с `http://`
+- если уже есть нормальный домен и нужен стандартный production path с TLS, использовать обычный host без схемы
 
 ## Первый деплой
 
@@ -101,7 +115,13 @@ GitHub Actions workflow после deploy уже делает smoke check лок
 curl -H "Host: $APP_DOMAIN" http://127.0.0.1/api/health
 ```
 
-Для внешней ручной проверки, если домен уже смотрит на сервер:
+Для внешней ручной проверки, если используется bootstrap по IP/HTTP:
+
+```bash
+curl http://$APP_DOMAIN/api/health
+```
+
+Если уже используется нормальный домен с TLS:
 
 ```bash
 curl https://$APP_DOMAIN/api/health
@@ -117,7 +137,8 @@ curl https://$APP_DOMAIN/api/health
 
 Открыть в браузере:
 
-- `https://$APP_DOMAIN`
+- bootstrap по IP/HTTP: `http://$APP_DOMAIN`
+- нормальный домен/TLS: `https://$APP_DOMAIN`
 
 Ожидаемый результат:
 - открывается стартовый экран `Nutrition App v2`
@@ -145,10 +166,15 @@ docker compose -f infra/docker/docker-compose.prod.yml logs frontend --tail=100
 docker compose -f infra/docker/docker-compose.prod.yml logs caddy --tail=100
 ```
 
-### Проверить, что домен реально совпадает с `APP_DOMAIN`
+### Проверить, что `APP_DOMAIN` и `CADDY_SITE_ADDRESS` согласованы
 
-Если в `Caddyfile.production` указан `{$APP_DOMAIN:localhost}`, а DNS смотрит не туда или домен не совпадает, Caddy не сможет корректно обслуживать live URL.
-Отсутствующий или пустой `APP_DOMAIN` больше не ломает парсинг Caddyfile/compose: контейнер получит fallback `localhost`. Но deploy всё равно будет в некорректном состоянии: Caddy матчится на `localhost`, а smoke/external checks будут бесполезны, пока не задан реальный host.
+Если для bootstrap по IP нужен plain HTTP, а `CADDY_SITE_ADDRESS` оставлен как просто `65.109.3.45` без `http://`, Caddy воспримет это как HTTPS-адрес и начнёт auto-HTTPS/redirect поведение.
+
+Если уже есть реальный домен и нужен штатный production path, наоборот нужно использовать обычный host без схемы:
+- `APP_DOMAIN=nutrition.example.com`
+- `CADDY_SITE_ADDRESS=nutrition.example.com`
+
+Отсутствующие или пустые переменные теперь не ломают парсинг Caddyfile/compose: Caddy получит fallback `localhost`. Но это только safe fallback для валидации, а не корректная live-конфигурация.
 
 ## Базовый recovery
 

--- a/infra/caddy/Caddyfile.production
+++ b/infra/caddy/Caddyfile.production
@@ -1,11 +1,11 @@
-{$APP_DOMAIN:localhost} {
-  encode gzip
+{$CADDY_SITE_ADDRESS:localhost} {
+	encode gzip
 
-  handle /api/* {
-    reverse_proxy backend:8080
-  }
+	handle /api/* {
+		reverse_proxy backend:8080
+	}
 
-  handle {
-    reverse_proxy frontend:80
-  }
+	handle {
+		reverse_proxy frontend:80
+	}
 }

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -46,6 +46,7 @@ services:
       - backend
     environment:
       APP_DOMAIN: ${APP_DOMAIN:-localhost}
+      CADDY_SITE_ADDRESS: ${CADDY_SITE_ADDRESS:-localhost}
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Context
The app is already working on the server locally, but bootstrap testing from another machine by IP was still failing.

Root cause: Caddy was using the same host value for both smoke checks and its site label. When that value was an IP like `65.109.3.45`, Caddy treated it as an HTTPS address and enabled auto-HTTPS plus HTTP→HTTPS redirects. That broke plain HTTP bootstrap access from another machine before a real domain/TLS setup existed.

## Changes
- changed production Caddy site label from `APP_DOMAIN` to a dedicated `CADDY_SITE_ADDRESS` variable
- added `CADDY_SITE_ADDRESS` to the `caddy` service environment in `infra/docker/docker-compose.prod.yml`
- documented the two supported modes:
  - bootstrap by IP/HTTP: `APP_DOMAIN=65.109.3.45`, `CADDY_SITE_ADDRESS=http://65.109.3.45`
  - normal domain/TLS: `APP_DOMAIN=nutrition.example.com`, `CADDY_SITE_ADDRESS=nutrition.example.com`
- updated `README.md`, `docs/LIVE_RUNBOOK.md`, and `docs/GITHUB_SETUP.md` to explain the bootstrap-vs-domain split

## How it was tested
- validated prod compose config: `docker compose -f infra/docker/docker-compose.prod.yml config`
- validated production Caddyfile with bootstrap HTTP-by-IP mode: `CADDY_SITE_ADDRESS=http://65.109.3.45 caddy validate --config infra/caddy/Caddyfile.production --adapter caddyfile`
- confirmed that in bootstrap mode Caddy logs `server is listening only on the HTTP port, so no automatic HTTPS will be applied to this server`
- validated production Caddyfile with normal domain/TLS mode: `CADDY_SITE_ADDRESS=nutrition.example.com caddy validate --config infra/caddy/Caddyfile.production --adapter caddyfile`
- confirmed that in domain mode Caddy logs normal HTTPS + redirect behavior

## Notes
- routing is unchanged: `/api/* -> backend:8080`, everything else -> `frontend:80`
- `APP_DOMAIN` still matters for smoke checks and documentation, but `CADDY_SITE_ADDRESS` now controls Caddy listener behavior
- for bootstrap by IP, `CADDY_SITE_ADDRESS` must include the `http://` scheme; a bare IP will bring back auto-HTTPS behavior
