### PR TITLE
Stabilize backend readiness during deploy

### DIFF
--- a/.github/workflows/deploy-ssh.yml
+++ b/.github/workflows/deploy-ssh.yml
@@ -117,6 +117,36 @@ jobs:
           printf '%s\n' "$GITHUB_SHA" > .deploy-revision
           EOF
 
+      - name: Wait for backend readiness on server
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PORT: ${{ env.SSH_PORT }}
+          DEPLOY_PATH: ${{ env.DEPLOY_PATH }}
+        run: |
+          set -euo pipefail
+          ssh -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" \
+            "DEPLOY_PATH='$DEPLOY_PATH' bash -s" <<'EOF'
+          set -euo pipefail
+          cd "$DEPLOY_PATH"
+
+          timeout 180 sh -c '
+            while :; do
+              container_id=$(docker compose --env-file "$DEPLOY_PATH/.env" -f infra/docker/docker-compose.prod.yml ps -q backend)
+              if [ -n "$container_id" ]; then
+                status=$(docker inspect --format "{{if .State.Health}}{{.State.Health.Status}}{{else}}starting{{end}}" "$container_id")
+                if [ "$status" = "healthy" ]; then
+                  exit 0
+                fi
+                echo "backend health: $status"
+              else
+                echo "backend container not created yet"
+              fi
+              sleep 3
+            done
+          '
+          EOF
+
       - name: Smoke check /api/health via local Caddy
         env:
           SSH_HOST: ${{ secrets.SSH_HOST }}
@@ -139,9 +169,9 @@ jobs:
           fi
 
           curl --fail --silent --show-error \
-            --retry 10 \
+            --retry 20 \
             --retry-delay 3 \
-            --retry-connrefused \
+            --retry-all-errors \
             -H "Host: $APP_DOMAIN" \
             http://127.0.0.1/api/health >/dev/null
           EOF

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,6 +5,9 @@ COPY src ./src
 RUN mvn -q -DskipTests package
 
 FROM eclipse-temurin:21-jre
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 EXPOSE 8080

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -19,6 +19,10 @@ server:
   port: ${PORT:8080}
 
 management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
   endpoints:
     web:
       exposure:

--- a/docs/GITHUB_SETUP.md
+++ b/docs/GITHUB_SETUP.md
@@ -42,13 +42,15 @@ cd nutrition-app-v2
 2. поднимает SSH agent и known_hosts
 3. синхронизирует репозиторий на сервер в `/opt/nutrition-app-v2`
 4. запускает `docker compose --env-file /opt/nutrition-app-v2/.env -f infra/docker/docker-compose.prod.yml up -d --build`
-5. делает smoke check через `http://127.0.0.1/api/health` с `Host: $APP_DOMAIN`
+5. ждёт backend readiness (`/actuator/health/readiness` внутри контейнера)
+6. делает smoke check через `http://127.0.0.1/api/health` с `Host: $APP_DOMAIN`
 
 Важно:
 - workflow не хранит production secrets в репозитории
 - серверный `.env` остаётся только на сервере и не перезаписывается из GitHub Actions
 - `storage/` и `.env` исключены из sync, чтобы не затереть runtime state
 - production compose вызывается с явным `--env-file`, потому что `env_file:` в сервисах не участвует в compose interpolation `${...}`
+- backend теперь имеет Docker healthcheck на `/actuator/health/readiness`, поэтому smoke check стартует только после реальной готовности Spring Boot/Flyway, а не сразу после запуска контейнера
 
 ## 4. GitHub Actions secrets for SSH deploy
 

--- a/docs/LIVE_RUNBOOK.md
+++ b/docs/LIVE_RUNBOOK.md
@@ -109,7 +109,9 @@ docker compose --env-file /opt/nutrition-app-v2/.env -f infra/docker/docker-comp
 
 ### 4. Backend health
 
-GitHub Actions workflow после deploy уже делает smoke check локально на сервере через Caddy:
+Backend теперь считается ready только после успешного Spring Boot startup + Flyway migrations: Docker healthcheck бьёт в `http://127.0.0.1:8080/actuator/health/readiness` внутри контейнера.
+
+GitHub Actions workflow после deploy сначала дожидается этого readiness-состояния и только потом делает smoke check локально на сервере через Caddy:
 
 ```bash
 curl -H "Host: $APP_DOMAIN" http://127.0.0.1/api/health
@@ -152,6 +154,14 @@ curl https://$APP_DOMAIN/api/health
 
 ```bash
 docker compose --env-file /opt/nutrition-app-v2/.env -f infra/docker/docker-compose.prod.yml logs backend --tail=100
+docker compose --env-file /opt/nutrition-app-v2/.env -f infra/docker/docker-compose.prod.yml ps
+```
+
+Если нужно явно посмотреть readiness внутри контейнера:
+
+```bash
+docker compose --env-file /opt/nutrition-app-v2/.env -f infra/docker/docker-compose.prod.yml exec backend \
+  curl --silent --show-error http://127.0.0.1:8080/actuator/health/readiness
 ```
 
 ### Проверить frontend

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -30,6 +30,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail --silent http://127.0.0.1:8080/actuator/health/readiness >/dev/null || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 24
+      start_period: 20s
 
   frontend:
     build:
@@ -42,8 +48,10 @@ services:
     image: caddy:2
     restart: unless-stopped
     depends_on:
-      - frontend
-      - backend
+      frontend:
+        condition: service_started
+      backend:
+        condition: service_healthy
     environment:
       APP_DOMAIN: ${APP_DOMAIN:-localhost}
       CADDY_SITE_ADDRESS: ${CADDY_SITE_ADDRESS:-localhost}

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -28,6 +28,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail --silent http://127.0.0.1:8080/actuator/health/readiness >/dev/null || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 24
+      start_period: 20s
     ports:
       - "8080:8080"
 
@@ -40,8 +46,10 @@ services:
   caddy:
     image: caddy:2
     depends_on:
-      - frontend
-      - backend
+      frontend:
+        condition: service_started
+      backend:
+        condition: service_healthy
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Context
Production deploys could fail with transient `502` during smoke checks even when the stack was otherwise close to healthy.

Root cause: the deploy workflow was checking `/api/health` through Caddy before the Spring Boot backend had fully become ready after Flyway and startup. At that moment Caddy could resolve the backend container name, but `backend:8080` still refused connections, so the workflow failed on a temporary condition instead of a real broken deploy.

## Changes
- enabled Spring Boot health probes in `backend/src/main/resources/application.yml`
- added backend container healthchecks to both dev and prod compose files, using `/actuator/health/readiness`
- added `curl` to the backend runtime image so the healthcheck can run inside the container
- changed `caddy` dependency on `backend` to `condition: service_healthy`
- updated the GitHub Actions deploy workflow to wait for backend health to become `healthy` before running the smoke check
- made the smoke check more resilient with more retries and `--retry-all-errors`
- updated `docs/GITHUB_SETUP.md` and `docs/LIVE_RUNBOOK.md` to document the readiness behavior

## How it was tested
- parsed `.github/workflows/deploy-ssh.yml` successfully with Python + YAML
- validated `docker compose -f infra/docker/docker-compose.yml config`
- validated `docker compose -f infra/docker/docker-compose.prod.yml config`
- manually reviewed the healthcheck/readiness flow end-to-end across backend config, compose, and deploy workflow

## Notes
- routing is unchanged
- this is intended to fix startup timing / readiness races, not change application behavior
- local `mvn test` / full image build validation was limited by this machine environment, but compose/workflow validation passed
