### PR TITLE
feat(frontend): add today summary block with mock data

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,7 @@
+import { TodaySummaryBlock } from './features/today-summary/TodaySummaryBlock'
+import { getTodaySummaryMock } from './features/today-summary/mockTodaySummary'
+
 const daySummary = {
-  dateLabel: 'Сегодня, 3 апреля',
-  calories: 1640,
-  protein: 108,
-  fiber: 24,
-  goal: 2100,
   water: '1.8 / 2.5 л',
   mood: 'Стабильная энергия',
   score: 82,
@@ -173,7 +171,8 @@ function MealCard({ title, timeRange, calories, protein, items, hint, accent }) 
 }
 
 export default function App() {
-  const remainingCalories = daySummary.goal - daySummary.calories
+  const todaySummary = getTodaySummaryMock()
+  const remainingCalories = todaySummary.remainingCalories
 
   return (
     <main className="app-shell">
@@ -187,6 +186,8 @@ export default function App() {
           <span>Current day · meal logging · analyzer-ready shell</span>
         </div>
       </section>
+
+      <TodaySummaryBlock summary={todaySummary} />
 
       <section className="hero-card panel">
         <div className="hero-card__main">
@@ -218,9 +219,9 @@ export default function App() {
       </section>
 
       <section className="metrics-grid">
-        <MetricCard label={daySummary.dateLabel} value={daySummary.calories} suffix="ккал" accent detail="Из подтверждённых meal entries" />
-        <MetricCard label="Белок" value={daySummary.protein} suffix="г" detail="Сильнее всего закрыт после обеда" />
-        <MetricCard label="Клетчатка" value={daySummary.fiber} suffix="г" detail="Нужно ещё немного овощей вечером" />
+        <MetricCard label={todaySummary.dateLabel} value={todaySummary.consumedCalories} suffix="ккал" accent detail="Из подтверждённых meal entries" />
+        <MetricCard label="Белок" value={todaySummary.proteinGrams} suffix="г" detail="Сильнее всего закрыт после обеда" />
+        <MetricCard label="Клетчатка" value={todaySummary.fiberGrams} suffix="г" detail="Нужно ещё немного овощей вечером" />
         <MetricCard label="До цели" value={remainingCalories} suffix="ккал" detail="Можно закрыть ужином без перегруза" />
       </section>
 

--- a/frontend/src/features/today-summary/TodaySummaryBlock.jsx
+++ b/frontend/src/features/today-summary/TodaySummaryBlock.jsx
@@ -1,0 +1,30 @@
+function SummaryItem({ label, value, unit }) {
+  return (
+    <article className="today-summary__item">
+      <span className="today-summary__label">{label}</span>
+      <strong className="today-summary__value">
+        {value}
+        {unit ? <span className="today-summary__unit"> {unit}</span> : null}
+      </strong>
+    </article>
+  )
+}
+
+export function TodaySummaryBlock({ summary }) {
+  return (
+    <section className="panel today-summary" aria-label="Today nutrition summary">
+      <header className="today-summary__header">
+        <p className="eyebrow eyebrow--soft">Today Summary</p>
+        <h2>{summary.dateLabel}</h2>
+      </header>
+
+      <div className="today-summary__grid">
+        <SummaryItem label="Consumed today" value={summary.consumedCalories} unit="kcal" />
+        <SummaryItem label="Daily target" value={summary.dailyTargetCalories} unit="kcal" />
+        <SummaryItem label="Remaining calories" value={summary.remainingCalories} unit="kcal" />
+        <SummaryItem label="Protein today" value={summary.proteinGrams} unit="g" />
+        <SummaryItem label="Fiber today" value={summary.fiberGrams} unit="g" />
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/features/today-summary/mockTodaySummary.js
+++ b/frontend/src/features/today-summary/mockTodaySummary.js
@@ -1,0 +1,26 @@
+const todaySummaryMock = {
+  dateLabel: 'Сегодня, 3 апреля',
+  consumedCalories: 1640,
+  dailyTargetCalories: 2100,
+  proteinGrams: 108,
+  fiberGrams: 24,
+}
+
+function normalizeSummary(summary) {
+  const remainingCalories = Math.max(0, summary.dailyTargetCalories - summary.consumedCalories)
+
+  return {
+    ...summary,
+    remainingCalories,
+  }
+}
+
+/**
+ * Temporary source for Today Summary data.
+ *
+ * Replace this function body with backend/API call later,
+ * keeping the returned data shape stable for the UI component.
+ */
+export function getTodaySummaryMock() {
+  return normalizeSummary(todaySummaryMock)
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -84,6 +84,46 @@ ul {
   margin-bottom: 18px;
 }
 
+.today-summary {
+  padding: 22px;
+  margin-bottom: 16px;
+}
+
+.today-summary__header {
+  margin-bottom: 14px;
+}
+
+.today-summary__grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.today-summary__item {
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.54);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.today-summary__label {
+  display: block;
+  color: #8ba2bf;
+  font-size: 0.82rem;
+}
+
+.today-summary__value {
+  display: block;
+  margin-top: 8px;
+  font-size: clamp(1.12rem, 1.8vw, 1.5rem);
+  line-height: 1;
+}
+
+.today-summary__unit {
+  font-size: 0.92rem;
+  color: #dbeafe;
+}
+
 .topbar__badge {
   display: inline-flex;
   align-items: center;
@@ -520,6 +560,10 @@ h3 {
 }
 
 @media (max-width: 900px) {
+  .today-summary__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .metrics-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -541,6 +585,14 @@ h3 {
 }
 
 @media (max-width: 640px) {
+  .today-summary {
+    padding: 18px;
+  }
+
+  .today-summary__grid {
+    grid-template-columns: 1fr;
+  }
+
   .app-shell {
     padding-inline: 12px;
   }


### PR DESCRIPTION
Context
- Implements task #29 as a focused frontend slice while backend wiring is still pending.
- Adds a Today Summary block using temporary mock data in a backend-ready shape.

Changes
- add `TodaySummaryBlock` component
- add `mockTodaySummary` data source and normalization helper
- wire the block into `App.jsx`
- add responsive styles for the summary grid

How it was tested
- `cd frontend && npm run build`

Closes #29