### PR TITLE
feat(backend): add nutrition DB foundation

### DIFF
--- a/backend/src/main/java/com/aiduparc/nutrition/history/model/DailyNutritionEntryEntity.java
+++ b/backend/src/main/java/com/aiduparc/nutrition/history/model/DailyNutritionEntryEntity.java
@@ -1,0 +1,151 @@
+package com.aiduparc.nutrition.history.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+@Entity
+@Table(
+    name = "daily_nutrition_entries",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_daily_entries_user_date", columnNames = {"user_id", "entry_date"})
+    }
+)
+public class DailyNutritionEntryEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "entry_date", nullable = false)
+    private java.time.LocalDate entryDate;
+
+    @Column(name = "weight_kg", precision = 6, scale = 2)
+    private BigDecimal weightKg;
+
+    @Column(name = "calories_consumed_kcal", precision = 10, scale = 2, nullable = false)
+    private BigDecimal caloriesConsumedKcal;
+
+    @Column(name = "calorie_target_kcal", precision = 10, scale = 2)
+    private BigDecimal calorieTargetKcal;
+
+    @Column(name = "protein_g", precision = 10, scale = 2)
+    private BigDecimal proteinGrams;
+
+    @Column(name = "fiber_g", precision = 10, scale = 2)
+    private BigDecimal fiberGrams;
+
+    @Column(name = "notes")
+    private String notes;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public java.time.LocalDate getEntryDate() {
+        return entryDate;
+    }
+
+    public void setEntryDate(java.time.LocalDate entryDate) {
+        this.entryDate = entryDate;
+    }
+
+    public BigDecimal getWeightKg() {
+        return weightKg;
+    }
+
+    public void setWeightKg(BigDecimal weightKg) {
+        this.weightKg = weightKg;
+    }
+
+    public BigDecimal getCaloriesConsumedKcal() {
+        return caloriesConsumedKcal;
+    }
+
+    public void setCaloriesConsumedKcal(BigDecimal caloriesConsumedKcal) {
+        this.caloriesConsumedKcal = caloriesConsumedKcal;
+    }
+
+    public BigDecimal getCalorieTargetKcal() {
+        return calorieTargetKcal;
+    }
+
+    public void setCalorieTargetKcal(BigDecimal calorieTargetKcal) {
+        this.calorieTargetKcal = calorieTargetKcal;
+    }
+
+    public BigDecimal getProteinGrams() {
+        return proteinGrams;
+    }
+
+    public void setProteinGrams(BigDecimal proteinGrams) {
+        this.proteinGrams = proteinGrams;
+    }
+
+    public BigDecimal getFiberGrams() {
+        return fiberGrams;
+    }
+
+    public void setFiberGrams(BigDecimal fiberGrams) {
+        this.fiberGrams = fiberGrams;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    @PrePersist
+    void onCreate() {
+        var now = OffsetDateTime.now(ZoneOffset.UTC);
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+}

--- a/backend/src/main/java/com/aiduparc/nutrition/history/model/DailyNutritionEntrySnapshot.java
+++ b/backend/src/main/java/com/aiduparc/nutrition/history/model/DailyNutritionEntrySnapshot.java
@@ -1,0 +1,45 @@
+package com.aiduparc.nutrition.history.model;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+public record DailyNutritionEntrySnapshot(
+    UUID id,
+    UUID userId,
+    LocalDate entryDate,
+    BigDecimal weightKg,
+    BigDecimal caloriesConsumedKcal,
+    BigDecimal calorieTargetKcal,
+    BigDecimal proteinGrams,
+    BigDecimal fiberGrams,
+    String notes,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt
+) {
+
+    public static DailyNutritionEntrySnapshot fromEntity(DailyNutritionEntryEntity entity) {
+        return new DailyNutritionEntrySnapshot(
+            entity.getId(),
+            entity.getUserId(),
+            entity.getEntryDate(),
+            entity.getWeightKg(),
+            entity.getCaloriesConsumedKcal(),
+            entity.getCalorieTargetKcal(),
+            entity.getProteinGrams(),
+            entity.getFiberGrams(),
+            entity.getNotes(),
+            entity.getCreatedAt(),
+            entity.getUpdatedAt()
+        );
+    }
+
+    public Optional<BigDecimal> calorieBalanceKcal() {
+        if (calorieTargetKcal == null || caloriesConsumedKcal == null) {
+            return Optional.empty();
+        }
+        return Optional.of(calorieTargetKcal.subtract(caloriesConsumedKcal));
+    }
+}

--- a/backend/src/main/java/com/aiduparc/nutrition/history/repository/DailyNutritionEntryRepository.java
+++ b/backend/src/main/java/com/aiduparc/nutrition/history/repository/DailyNutritionEntryRepository.java
@@ -1,0 +1,19 @@
+package com.aiduparc.nutrition.history.repository;
+
+import com.aiduparc.nutrition.history.model.DailyNutritionEntryEntity;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyNutritionEntryRepository extends JpaRepository<DailyNutritionEntryEntity, UUID> {
+
+    Optional<DailyNutritionEntryEntity> findByUserIdAndEntryDate(UUID userId, LocalDate entryDate);
+
+    List<DailyNutritionEntryEntity> findByUserIdAndEntryDateBetweenOrderByEntryDateAsc(
+        UUID userId,
+        LocalDate start,
+        LocalDate end
+    );
+}

--- a/backend/src/main/java/com/aiduparc/nutrition/history/service/NutritionHistoryService.java
+++ b/backend/src/main/java/com/aiduparc/nutrition/history/service/NutritionHistoryService.java
@@ -1,0 +1,67 @@
+package com.aiduparc.nutrition.history.service;
+
+import com.aiduparc.nutrition.history.model.DailyNutritionEntryEntity;
+import com.aiduparc.nutrition.history.model.DailyNutritionEntrySnapshot;
+import com.aiduparc.nutrition.history.repository.DailyNutritionEntryRepository;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class NutritionHistoryService {
+
+    private final DailyNutritionEntryRepository repository;
+
+    public NutritionHistoryService(DailyNutritionEntryRepository repository) {
+        this.repository = repository;
+    }
+
+    public Optional<DailyNutritionEntrySnapshot> findByUserAndDate(UUID userId, LocalDate entryDate) {
+        return repository.findByUserIdAndEntryDate(userId, entryDate)
+            .map(DailyNutritionEntrySnapshot::fromEntity);
+    }
+
+    public List<DailyNutritionEntrySnapshot> findByUserAndRange(UUID userId, LocalDate fromInclusive, LocalDate toInclusive) {
+        return repository.findByUserIdAndEntryDateBetweenOrderByEntryDateAsc(userId, fromInclusive, toInclusive)
+            .stream()
+            .map(DailyNutritionEntrySnapshot::fromEntity)
+            .toList();
+    }
+
+    @Transactional
+    public DailyNutritionEntrySnapshot upsert(UpsertDailyNutritionEntryCommand command) {
+        DailyNutritionEntryEntity entity = repository
+            .findByUserIdAndEntryDate(command.userId(), command.entryDate())
+            .orElseGet(DailyNutritionEntryEntity::new);
+
+        entity.setUserId(command.userId());
+        entity.setEntryDate(command.entryDate());
+        entity.setWeightKg(command.weightKg());
+        entity.setCaloriesConsumedKcal(command.caloriesConsumedKcal());
+        entity.setCalorieTargetKcal(command.calorieTargetKcal());
+        entity.setProteinGrams(command.proteinGrams());
+        entity.setFiberGrams(command.fiberGrams());
+        entity.setNotes(command.notes());
+
+        DailyNutritionEntryEntity saved = repository.save(entity);
+        return DailyNutritionEntrySnapshot.fromEntity(saved);
+    }
+
+    public record UpsertDailyNutritionEntryCommand(
+        @NotNull UUID userId,
+        @NotNull LocalDate entryDate,
+        @NotNull BigDecimal caloriesConsumedKcal,
+        BigDecimal calorieTargetKcal,
+        BigDecimal weightKg,
+        BigDecimal proteinGrams,
+        BigDecimal fiberGrams,
+        String notes
+    ) {
+    }
+}

--- a/backend/src/main/resources/db/migration/V2__daily_nutrition_history.sql
+++ b/backend/src/main/resources/db/migration/V2__daily_nutrition_history.sql
@@ -1,0 +1,17 @@
+create table if not exists daily_nutrition_entries (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references users(id) on delete cascade,
+    entry_date date not null,
+    weight_kg numeric(6,2),
+    calories_consumed_kcal numeric(10,2) not null,
+    calorie_target_kcal numeric(10,2),
+    protein_g numeric(10,2),
+    fiber_g numeric(10,2),
+    notes text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    unique (user_id, entry_date)
+);
+
+create index if not exists idx_daily_nutrition_entries_user_date
+    on daily_nutrition_entries (user_id, entry_date);

--- a/backend/src/test/java/com/aiduparc/nutrition/history/model/DailyNutritionEntrySnapshotTest.java
+++ b/backend/src/test/java/com/aiduparc/nutrition/history/model/DailyNutritionEntrySnapshotTest.java
@@ -1,0 +1,51 @@
+package com.aiduparc.nutrition.history.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class DailyNutritionEntrySnapshotTest {
+
+    @Test
+    void calorieBalanceIsComputedFromTargetMinusConsumed() {
+        DailyNutritionEntrySnapshot snapshot = new DailyNutritionEntrySnapshot(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            LocalDate.of(2026, 4, 5),
+            new BigDecimal("82.40"),
+            new BigDecimal("2100.00"),
+            new BigDecimal("2400.00"),
+            new BigDecimal("150.00"),
+            new BigDecimal("28.00"),
+            "training day",
+            OffsetDateTime.now(ZoneOffset.UTC),
+            OffsetDateTime.now(ZoneOffset.UTC)
+        );
+
+        assertThat(snapshot.calorieBalanceKcal()).contains(new BigDecimal("300.00"));
+    }
+
+    @Test
+    void calorieBalanceIsEmptyWhenTargetIsMissing() {
+        DailyNutritionEntrySnapshot snapshot = new DailyNutritionEntrySnapshot(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            LocalDate.of(2026, 4, 5),
+            null,
+            new BigDecimal("2100.00"),
+            null,
+            null,
+            null,
+            null,
+            OffsetDateTime.now(ZoneOffset.UTC),
+            OffsetDateTime.now(ZoneOffset.UTC)
+        );
+
+        assertThat(snapshot.calorieBalanceKcal()).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/aiduparc/nutrition/history/service/NutritionHistoryServiceTest.java
+++ b/backend/src/test/java/com/aiduparc/nutrition/history/service/NutritionHistoryServiceTest.java
@@ -1,0 +1,96 @@
+package com.aiduparc.nutrition.history.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aiduparc.nutrition.history.model.DailyNutritionEntryEntity;
+import com.aiduparc.nutrition.history.repository.DailyNutritionEntryRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NutritionHistoryServiceTest {
+
+    @Mock
+    private DailyNutritionEntryRepository repository;
+
+    @InjectMocks
+    private NutritionHistoryService service;
+
+    @Test
+    void upsertCreatesNewEntryWhenDateIsMissing() {
+        UUID userId = UUID.randomUUID();
+        LocalDate entryDate = LocalDate.of(2026, 4, 5);
+
+        when(repository.findByUserIdAndEntryDate(userId, entryDate)).thenReturn(Optional.empty());
+        when(repository.save(any(DailyNutritionEntryEntity.class))).thenAnswer(invocation -> {
+            DailyNutritionEntryEntity entity = invocation.getArgument(0);
+            entity.setId(UUID.randomUUID());
+            return entity;
+        });
+
+        NutritionHistoryService.UpsertDailyNutritionEntryCommand command = new NutritionHistoryService.UpsertDailyNutritionEntryCommand(
+            userId,
+            entryDate,
+            new BigDecimal("2200.00"),
+            new BigDecimal("2500.00"),
+            new BigDecimal("82.10"),
+            new BigDecimal("165.00"),
+            new BigDecimal("27.00"),
+            "imported from sheet"
+        );
+
+        var saved = service.upsert(command);
+
+        ArgumentCaptor<DailyNutritionEntryEntity> entityCaptor = ArgumentCaptor.forClass(DailyNutritionEntryEntity.class);
+        verify(repository).save(entityCaptor.capture());
+        DailyNutritionEntryEntity persisted = entityCaptor.getValue();
+
+        assertThat(persisted.getUserId()).isEqualTo(userId);
+        assertThat(persisted.getEntryDate()).isEqualTo(entryDate);
+        assertThat(persisted.getCaloriesConsumedKcal()).isEqualByComparingTo("2200.00");
+        assertThat(saved.calorieBalanceKcal()).contains(new BigDecimal("300.00"));
+    }
+
+    @Test
+    void upsertUpdatesExistingEntryForSameUserAndDate() {
+        UUID userId = UUID.randomUUID();
+        LocalDate entryDate = LocalDate.of(2026, 4, 5);
+        DailyNutritionEntryEntity existing = new DailyNutritionEntryEntity();
+        existing.setId(UUID.randomUUID());
+        existing.setUserId(userId);
+        existing.setEntryDate(entryDate);
+        existing.setCaloriesConsumedKcal(new BigDecimal("1800.00"));
+        existing.setNotes("old");
+
+        when(repository.findByUserIdAndEntryDate(userId, entryDate)).thenReturn(Optional.of(existing));
+        when(repository.save(any(DailyNutritionEntryEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        NutritionHistoryService.UpsertDailyNutritionEntryCommand command = new NutritionHistoryService.UpsertDailyNutritionEntryCommand(
+            userId,
+            entryDate,
+            new BigDecimal("2050.00"),
+            null,
+            null,
+            new BigDecimal("140.00"),
+            new BigDecimal("24.00"),
+            "corrected"
+        );
+
+        var saved = service.upsert(command);
+
+        assertThat(saved.id()).isEqualTo(existing.getId());
+        assertThat(saved.caloriesConsumedKcal()).isEqualByComparingTo("2050.00");
+        assertThat(saved.notes()).isEqualTo("corrected");
+    }
+}

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -61,6 +61,26 @@
 - estimated_fiber_g (numeric, nullable)
 - created_at
 
+## daily_nutrition_entries
+- id (uuid, pk)
+- user_id (uuid, fk -> users)
+- entry_date (date)
+- weight_kg (numeric, nullable)
+- calories_consumed_kcal (numeric)
+- calorie_target_kcal (numeric, nullable)
+- protein_g (numeric, nullable)
+- fiber_g (numeric, nullable)
+- notes (text, nullable)
+- created_at
+- updated_at
+- unique (user_id, entry_date)
+
+### Source of truth vs derived values
+- Source of truth: `entry_date`, `weight_kg`, `calories_consumed_kcal`, `calorie_target_kcal`, `protein_g`, `fiber_g`, `notes`
+- Derived on the fly: `calorie_balance_kcal = calorie_target_kcal - calories_consumed_kcal`, weekly/monthly aggregates, rolling streaks, macro completion %
+
+Only persist the raw day inputs. Everything that can drift (aggregates, balances, streak counters) should be computed in SQL or the API layer so it always reflects the latest edits/import corrections.
+
 ## optional: audit_log
 - id (uuid, pk)
 - entity_type (text)

--- a/docs/NUTRITION_HISTORY_FOUNDATION.md
+++ b/docs/NUTRITION_HISTORY_FOUNDATION.md
@@ -1,0 +1,38 @@
+# Nutrition history foundation
+
+## Storage choice
+- **Database:** PostgreSQL (already part of the stack)
+- **Reasoning:**
+  - Native JSONB + numeric support for both analyzer drafts and precise nutrition metrics
+  - Mature Flyway integration already installed in the backend
+  - Easy to run locally via existing Docker Compose services and to host in production (single dependency)
+  - Strong tooling for analytics queries (CTEs, window functions) that will be needed for weekly/monthly rollups
+
+## Daily nutrition entry schema
+- `daily_nutrition_entries` is now the daily source of truth (one row per user + date)
+- Uniqueness is enforced at the database level (`user_id + entry_date`)
+- Required inputs per row: `entry_date`, `calories_consumed_kcal`, other nutrition values remain nullable to accept partial days/import gaps
+- Timestamp columns are managed via database defaults plus entity listeners so every change stays auditable
+
+### Source-of-truth fields
+| Field | Notes |
+| --- | --- |
+| `entry_date` | Calendar day the numbers belong to (UTC). |
+| `weight_kg` | Optional but persisted exactly as entered/imported. |
+| `calories_consumed_kcal` | Mandatory daily total from confirmed meals. |
+| `calorie_target_kcal` | Optional because historical imports may lack a target. |
+| `protein_g` / `fiber_g` | Optional but stored verbatim to keep parity with the spreadsheet. |
+| `notes` | Free-form annotations (e.g., “travel day”, “estimate from watch”). |
+
+### Derived fields (computed, not stored)
+- `calorie_balance_kcal = calorie_target_kcal - calories_consumed_kcal`
+- Weekly/monthly aggregates and moving averages
+- Completion percentages for protein/fiber targets
+- Any “streaks” or “consistency badges”
+
+Keeping derived values ephemeral ensures that imports, corrections, and analyzer replays never fall out of sync with cached totals.
+
+## Migration/bootstrap
+- Flyway migration `V2__daily_nutrition_history.sql` creates the new table + covering index on `(user_id, entry_date)`
+- Backend now contains JPA entities, repository accessors, and a `NutritionHistoryService` with an explicit `upsert` command to prepare for the upcoming CSV import step
+- Weekly/monthly aggregate endpoints can be layered on top of the service without further schema work


### PR DESCRIPTION
Context
- Implements the DB foundation slice for nutrition history.
- Establishes the first backend storage layer before CSV import and dashboard wiring.

Changes
- add persistence/domain/repository/service foundation for daily nutrition history
- add migration/bootstrap for the daily metrics table
- add backend configuration and application wiring needed for the history layer
- add backend tests for snapshot/history service behavior

How it was tested
- `cd backend && mvn test` on Java 21

Closes #26