### PR TITLE
feat(backend): photo analysis draft persistence + confirm flow

### DIFF
--- a/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/api/PhotoAnalysisDraftController.java
+++ b/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/api/PhotoAnalysisDraftController.java
@@ -1,0 +1,50 @@
+package com.aiduparc.nutrition.photoanalysis.draft.api;
+
+import com.aiduparc.nutrition.photoanalysis.draft.application.PhotoAnalysisDraftService;
+import com.aiduparc.nutrition.photoanalysis.draft.dto.ConfirmPhotoAnalysisDraftRequest;
+import com.aiduparc.nutrition.photoanalysis.draft.dto.CreatePhotoAnalysisDraftRequest;
+import com.aiduparc.nutrition.photoanalysis.draft.dto.PhotoAnalysisDraftResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/photo-analysis/drafts")
+public class PhotoAnalysisDraftController {
+
+    private final PhotoAnalysisDraftService draftService;
+
+    public PhotoAnalysisDraftController(PhotoAnalysisDraftService draftService) {
+        this.draftService = draftService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public PhotoAnalysisDraftResponse create(@Valid @RequestBody CreatePhotoAnalysisDraftRequest request) {
+        return draftService.create(request);
+    }
+
+    @GetMapping("/{draftId}")
+    @ResponseStatus(HttpStatus.OK)
+    public PhotoAnalysisDraftResponse get(@PathVariable UUID draftId) {
+        return draftService.get(draftId);
+    }
+
+    @PostMapping("/{draftId}/confirm")
+    @ResponseStatus(HttpStatus.OK)
+    public PhotoAnalysisDraftResponse confirm(@PathVariable UUID draftId,
+                                              @RequestBody(required = false) ConfirmPhotoAnalysisDraftRequest request) {
+        ConfirmPhotoAnalysisDraftRequest safeRequest = request == null
+                ? new ConfirmPhotoAnalysisDraftRequest(null, null, null, null)
+                : request;
+        return draftService.confirm(draftId, safeRequest);
+    }
+}
+

--- a/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/application/DefaultPhotoAnalysisDraftService.java
+++ b/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/application/DefaultPhotoAnalysisDraftService.java
@@ -1,0 +1,145 @@
+package com.aiduparc.nutrition.photoanalysis.draft.application;
+
+import com.aiduparc.nutrition.history.service.NutritionHistoryService;
+import com.aiduparc.nutrition.photoanalysis.application.dto.PhotoAnalysisResponse;
+import com.aiduparc.nutrition.photoanalysis.draft.dto.ConfirmPhotoAnalysisDraftRequest;
+import com.aiduparc.nutrition.photoanalysis.draft.dto.CreatePhotoAnalysisDraftRequest;
+import com.aiduparc.nutrition.photoanalysis.draft.dto.PhotoAnalysisDraftResponse;
+import com.aiduparc.nutrition.photoanalysis.draft.model.PhotoAnalysisDraftEntity;
+import com.aiduparc.nutrition.photoanalysis.draft.model.PhotoAnalysisDraftStatus;
+import com.aiduparc.nutrition.photoanalysis.draft.repository.PhotoAnalysisDraftRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@Transactional(readOnly = true)
+public class DefaultPhotoAnalysisDraftService implements PhotoAnalysisDraftService {
+
+    private final PhotoAnalysisDraftRepository repository;
+    private final NutritionHistoryService nutritionHistoryService;
+    private final ObjectMapper objectMapper;
+
+    public DefaultPhotoAnalysisDraftService(
+            PhotoAnalysisDraftRepository repository,
+            NutritionHistoryService nutritionHistoryService,
+            ObjectMapper objectMapper
+    ) {
+        this.repository = repository;
+        this.nutritionHistoryService = nutritionHistoryService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    @Transactional
+    public PhotoAnalysisDraftResponse create(CreatePhotoAnalysisDraftRequest request) {
+        PhotoAnalysisDraftEntity entity = new PhotoAnalysisDraftEntity();
+        entity.setUserId(request.userId());
+        entity.setEntryDate(request.entryDate());
+        entity.setStatus(PhotoAnalysisDraftStatus.DRAFT);
+        entity.setAnalysisJson(toJson(request.analysis()));
+        entity.setEstimatedCaloriesKcal(request.analysis().totals().calories());
+        entity.setEstimatedProteinG(request.analysis().totals().protein());
+        entity.setEstimatedFiberG(request.analysis().totals().fiber());
+
+        PhotoAnalysisDraftEntity saved = repository.save(entity);
+        return toResponse(saved);
+    }
+
+    @Override
+    public PhotoAnalysisDraftResponse get(UUID draftId) {
+        PhotoAnalysisDraftEntity entity = getExistingDraft(draftId);
+        return toResponse(entity);
+    }
+
+    @Override
+    @Transactional
+    public PhotoAnalysisDraftResponse confirm(UUID draftId, ConfirmPhotoAnalysisDraftRequest request) {
+        PhotoAnalysisDraftEntity entity = getExistingDraft(draftId);
+
+        if (entity.getStatus() == PhotoAnalysisDraftStatus.CONFIRMED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Draft already confirmed");
+        }
+
+        BigDecimal calories = firstNonNull(request.caloriesKcal(), entity.getEstimatedCaloriesKcal());
+        BigDecimal protein = firstNonNull(request.proteinG(), entity.getEstimatedProteinG());
+        BigDecimal fiber = firstNonNull(request.fiberG(), entity.getEstimatedFiberG());
+
+        var savedEntry = nutritionHistoryService.upsert(new NutritionHistoryService.UpsertDailyNutritionEntryCommand(
+                entity.getUserId(),
+                entity.getEntryDate(),
+                calories,
+                null,
+                null,
+                protein,
+                fiber,
+                request.notes()
+        ));
+
+        entity.setStatus(PhotoAnalysisDraftStatus.CONFIRMED);
+        entity.setConfirmedAt(OffsetDateTime.now(ZoneOffset.UTC));
+        entity.setConfirmedDailyEntryId(savedEntry.id());
+        entity.setEstimatedCaloriesKcal(calories);
+        entity.setEstimatedProteinG(protein);
+        entity.setEstimatedFiberG(fiber);
+
+        PhotoAnalysisDraftEntity updated = repository.save(entity);
+        return toResponse(updated);
+    }
+
+    private PhotoAnalysisDraftEntity getExistingDraft(UUID draftId) {
+        return repository.findById(draftId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Draft not found"));
+    }
+
+    private PhotoAnalysisDraftResponse toResponse(PhotoAnalysisDraftEntity entity) {
+        return new PhotoAnalysisDraftResponse(
+                entity.getId(),
+                entity.getUserId(),
+                entity.getEntryDate(),
+                entity.getStatus(),
+                fromJson(entity.getAnalysisJson()),
+                entity.getEstimatedCaloriesKcal(),
+                entity.getEstimatedProteinG(),
+                entity.getEstimatedFiberG(),
+                entity.getConfirmedDailyEntryId(),
+                entity.getConfirmedAt(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+
+    private String toJson(PhotoAnalysisResponse analysis) {
+        try {
+            return objectMapper.writeValueAsString(analysis);
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to serialize analysis draft", e);
+        }
+    }
+
+    private PhotoAnalysisResponse fromJson(String json) {
+        try {
+            return objectMapper.readValue(json, PhotoAnalysisResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to parse analysis draft", e);
+        }
+    }
+
+    private static BigDecimal firstNonNull(BigDecimal preferred, BigDecimal fallback) {
+        if (preferred != null) {
+            return preferred;
+        }
+        if (fallback != null) {
+            return fallback;
+        }
+        return BigDecimal.ZERO;
+    }
+}
+

--- a/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/application/PhotoAnalysisDraftService.java
+++ b/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/application/PhotoAnalysisDraftService.java
@@ -1,0 +1,15 @@
+package com.aiduparc.nutrition.photoanalysis.draft.application;
+
+import com.aiduparc.nutrition.photoanalysis.draft.dto.ConfirmPhotoAnalysisDraftRequest;
+import com.aiduparc.nutrition.photoanalysis.draft.dto.CreatePhotoAnalysisDraftRequest;
+import com.aiduparc.nutrition.photoanalysis.draft.dto.PhotoAnalysisDraftResponse;
+import java.util.UUID;
+
+public interface PhotoAnalysisDraftService {
+    PhotoAnalysisDraftResponse create(CreatePhotoAnalysisDraftRequest request);
+
+    PhotoAnalysisDraftResponse get(UUID draftId);
+
+    PhotoAnalysisDraftResponse confirm(UUID draftId, ConfirmPhotoAnalysisDraftRequest request);
+}
+

--- a/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/dto/ConfirmPhotoAnalysisDraftRequest.java
+++ b/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/dto/ConfirmPhotoAnalysisDraftRequest.java
@@ -1,0 +1,12 @@
+package com.aiduparc.nutrition.photoanalysis.draft.dto;
+
+import java.math.BigDecimal;
+
+public record ConfirmPhotoAnalysisDraftRequest(
+        BigDecimal caloriesKcal,
+        BigDecimal proteinG,
+        BigDecimal fiberG,
+        String notes
+) {
+}
+

--- a/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/dto/CreatePhotoAnalysisDraftRequest.java
+++ b/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/dto/CreatePhotoAnalysisDraftRequest.java
@@ -1,0 +1,15 @@
+package com.aiduparc.nutrition.photoanalysis.draft.dto;
+
+import com.aiduparc.nutrition.photoanalysis.application.dto.PhotoAnalysisResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record CreatePhotoAnalysisDraftRequest(
+        @NotNull UUID userId,
+        @NotNull LocalDate entryDate,
+        @NotNull @Valid PhotoAnalysisResponse analysis
+) {
+}
+

--- a/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/dto/PhotoAnalysisDraftResponse.java
+++ b/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/dto/PhotoAnalysisDraftResponse.java
@@ -1,0 +1,25 @@
+package com.aiduparc.nutrition.photoanalysis.draft.dto;
+
+import com.aiduparc.nutrition.photoanalysis.application.dto.PhotoAnalysisResponse;
+import com.aiduparc.nutrition.photoanalysis.draft.model.PhotoAnalysisDraftStatus;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record PhotoAnalysisDraftResponse(
+        UUID id,
+        UUID userId,
+        LocalDate entryDate,
+        PhotoAnalysisDraftStatus status,
+        PhotoAnalysisResponse analysis,
+        BigDecimal estimatedCaloriesKcal,
+        BigDecimal estimatedProteinG,
+        BigDecimal estimatedFiberG,
+        UUID confirmedDailyEntryId,
+        OffsetDateTime confirmedAt,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+) {
+}
+

--- a/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/model/PhotoAnalysisDraftEntity.java
+++ b/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/model/PhotoAnalysisDraftEntity.java
@@ -1,0 +1,164 @@
+package com.aiduparc.nutrition.photoanalysis.draft.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+@Entity
+@Table(name = "photo_analysis_drafts")
+public class PhotoAnalysisDraftEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "entry_date", nullable = false)
+    private LocalDate entryDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private PhotoAnalysisDraftStatus status;
+
+    @Column(name = "analysis_json", nullable = false)
+    private String analysisJson;
+
+    @Column(name = "estimated_calories_kcal", precision = 10, scale = 2)
+    private BigDecimal estimatedCaloriesKcal;
+
+    @Column(name = "estimated_protein_g", precision = 10, scale = 2)
+    private BigDecimal estimatedProteinG;
+
+    @Column(name = "estimated_fiber_g", precision = 10, scale = 2)
+    private BigDecimal estimatedFiberG;
+
+    @Column(name = "confirmed_daily_entry_id")
+    private UUID confirmedDailyEntryId;
+
+    @Column(name = "confirmed_at")
+    private OffsetDateTime confirmedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public LocalDate getEntryDate() {
+        return entryDate;
+    }
+
+    public void setEntryDate(LocalDate entryDate) {
+        this.entryDate = entryDate;
+    }
+
+    public PhotoAnalysisDraftStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(PhotoAnalysisDraftStatus status) {
+        this.status = status;
+    }
+
+    public String getAnalysisJson() {
+        return analysisJson;
+    }
+
+    public void setAnalysisJson(String analysisJson) {
+        this.analysisJson = analysisJson;
+    }
+
+    public BigDecimal getEstimatedCaloriesKcal() {
+        return estimatedCaloriesKcal;
+    }
+
+    public void setEstimatedCaloriesKcal(BigDecimal estimatedCaloriesKcal) {
+        this.estimatedCaloriesKcal = estimatedCaloriesKcal;
+    }
+
+    public BigDecimal getEstimatedProteinG() {
+        return estimatedProteinG;
+    }
+
+    public void setEstimatedProteinG(BigDecimal estimatedProteinG) {
+        this.estimatedProteinG = estimatedProteinG;
+    }
+
+    public BigDecimal getEstimatedFiberG() {
+        return estimatedFiberG;
+    }
+
+    public void setEstimatedFiberG(BigDecimal estimatedFiberG) {
+        this.estimatedFiberG = estimatedFiberG;
+    }
+
+    public UUID getConfirmedDailyEntryId() {
+        return confirmedDailyEntryId;
+    }
+
+    public void setConfirmedDailyEntryId(UUID confirmedDailyEntryId) {
+        this.confirmedDailyEntryId = confirmedDailyEntryId;
+    }
+
+    public OffsetDateTime getConfirmedAt() {
+        return confirmedAt;
+    }
+
+    public void setConfirmedAt(OffsetDateTime confirmedAt) {
+        this.confirmedAt = confirmedAt;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    @PrePersist
+    void onCreate() {
+        var now = OffsetDateTime.now(ZoneOffset.UTC);
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
+        createdAt = now;
+        updatedAt = now;
+        if (status == null) {
+            status = PhotoAnalysisDraftStatus.DRAFT;
+        }
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+}
+

--- a/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/model/PhotoAnalysisDraftStatus.java
+++ b/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/model/PhotoAnalysisDraftStatus.java
@@ -1,0 +1,7 @@
+package com.aiduparc.nutrition.photoanalysis.draft.model;
+
+public enum PhotoAnalysisDraftStatus {
+    DRAFT,
+    CONFIRMED
+}
+

--- a/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/repository/PhotoAnalysisDraftRepository.java
+++ b/backend/src/main/java/com/aiduparc/nutrition/photoanalysis/draft/repository/PhotoAnalysisDraftRepository.java
@@ -1,0 +1,11 @@
+package com.aiduparc.nutrition.photoanalysis.draft.repository;
+
+import com.aiduparc.nutrition.photoanalysis.draft.model.PhotoAnalysisDraftEntity;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhotoAnalysisDraftRepository extends JpaRepository<PhotoAnalysisDraftEntity, UUID> {
+    Optional<PhotoAnalysisDraftEntity> findById(UUID id);
+}
+

--- a/backend/src/main/resources/db/migration/V3__photo_analysis_drafts.sql
+++ b/backend/src/main/resources/db/migration/V3__photo_analysis_drafts.sql
@@ -1,0 +1,21 @@
+create table if not exists photo_analysis_drafts (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null,
+    entry_date date not null,
+    status text not null,
+    analysis_json text not null,
+    estimated_calories_kcal numeric(10,2),
+    estimated_protein_g numeric(10,2),
+    estimated_fiber_g numeric(10,2),
+    confirmed_daily_entry_id uuid references daily_nutrition_entries(id) on delete set null,
+    confirmed_at timestamptz,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_photo_analysis_drafts_user_date
+    on photo_analysis_drafts (user_id, entry_date);
+
+create index if not exists idx_photo_analysis_drafts_status
+    on photo_analysis_drafts (status);
+

--- a/backend/src/test/java/com/aiduparc/nutrition/photoanalysis/draft/api/PhotoAnalysisDraftControllerTest.java
+++ b/backend/src/test/java/com/aiduparc/nutrition/photoanalysis/draft/api/PhotoAnalysisDraftControllerTest.java
@@ -1,0 +1,129 @@
+package com.aiduparc.nutrition.photoanalysis.draft.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aiduparc.nutrition.photoanalysis.application.dto.AnalyzedFoodItem;
+import com.aiduparc.nutrition.photoanalysis.application.dto.PhotoAnalysisResponse;
+import com.aiduparc.nutrition.photoanalysis.application.dto.PhotoAnalysisTotals;
+import com.aiduparc.nutrition.photoanalysis.draft.application.PhotoAnalysisDraftService;
+import com.aiduparc.nutrition.photoanalysis.draft.dto.PhotoAnalysisDraftResponse;
+import com.aiduparc.nutrition.photoanalysis.draft.model.PhotoAnalysisDraftStatus;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(PhotoAnalysisDraftController.class)
+class PhotoAnalysisDraftControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PhotoAnalysisDraftService draftService;
+
+    @Test
+    void shouldCreateAndFetchDraft() throws Exception {
+        UUID draftId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        LocalDate entryDate = LocalDate.of(2026, 4, 6);
+
+        PhotoAnalysisDraftResponse response = new PhotoAnalysisDraftResponse(
+                draftId,
+                userId,
+                entryDate,
+                PhotoAnalysisDraftStatus.DRAFT,
+                sampleAnalysis(),
+                new BigDecimal("560"),
+                new BigDecimal("30"),
+                new BigDecimal("8"),
+                null,
+                null,
+                OffsetDateTime.now(),
+                OffsetDateTime.now()
+        );
+
+        when(draftService.create(any())).thenReturn(response);
+        when(draftService.get(draftId)).thenReturn(response);
+
+        mockMvc.perform(post("/api/photo-analysis/drafts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": "%s",
+                                  "entryDate": "2026-04-06",
+                                  "analysis": {
+                                    "items": [{
+                                      "name": "salad",
+                                      "portion": "250 g",
+                                      "calories": 560,
+                                      "protein": 30,
+                                      "fiber": 8,
+                                      "fat": 22,
+                                      "carbs": 50,
+                                      "confidence": 0.79
+                                    }],
+                                    "totals": {
+                                      "calories": 560,
+                                      "protein": 30,
+                                      "fiber": 8,
+                                      "fat": 22,
+                                      "carbs": 50
+                                    },
+                                    "confidence": 0.79,
+                                    "notes": ["ai suggestion"],
+                                    "needsUserConfirmation": true
+                                  }
+                                }
+                                """.formatted(userId)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(draftId.toString()))
+                .andExpect(jsonPath("$.status").value("DRAFT"));
+
+        mockMvc.perform(get("/api/photo-analysis/drafts/{draftId}", draftId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.analysis.totals.calories").value(560));
+
+        verify(draftService).create(any());
+        verify(draftService).get(draftId);
+    }
+
+    private static PhotoAnalysisResponse sampleAnalysis() {
+        return new PhotoAnalysisResponse(
+                List.of(new AnalyzedFoodItem(
+                        "salad",
+                        "250 g",
+                        new BigDecimal("560"),
+                        new BigDecimal("30"),
+                        new BigDecimal("8"),
+                        new BigDecimal("22"),
+                        new BigDecimal("50"),
+                        new BigDecimal("0.79")
+                )),
+                new PhotoAnalysisTotals(
+                        new BigDecimal("560"),
+                        new BigDecimal("30"),
+                        new BigDecimal("8"),
+                        new BigDecimal("22"),
+                        new BigDecimal("50")
+                ),
+                new BigDecimal("0.79"),
+                List.of("ai suggestion"),
+                true
+        );
+    }
+}
+

--- a/backend/src/test/java/com/aiduparc/nutrition/photoanalysis/draft/application/DefaultPhotoAnalysisDraftServiceTest.java
+++ b/backend/src/test/java/com/aiduparc/nutrition/photoanalysis/draft/application/DefaultPhotoAnalysisDraftServiceTest.java
@@ -1,0 +1,156 @@
+package com.aiduparc.nutrition.photoanalysis.draft.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aiduparc.nutrition.history.model.DailyNutritionEntrySnapshot;
+import com.aiduparc.nutrition.history.service.NutritionHistoryService;
+import com.aiduparc.nutrition.photoanalysis.application.dto.AnalyzedFoodItem;
+import com.aiduparc.nutrition.photoanalysis.application.dto.PhotoAnalysisResponse;
+import com.aiduparc.nutrition.photoanalysis.application.dto.PhotoAnalysisTotals;
+import com.aiduparc.nutrition.photoanalysis.draft.dto.ConfirmPhotoAnalysisDraftRequest;
+import com.aiduparc.nutrition.photoanalysis.draft.dto.CreatePhotoAnalysisDraftRequest;
+import com.aiduparc.nutrition.photoanalysis.draft.model.PhotoAnalysisDraftEntity;
+import com.aiduparc.nutrition.photoanalysis.draft.model.PhotoAnalysisDraftStatus;
+import com.aiduparc.nutrition.photoanalysis.draft.repository.PhotoAnalysisDraftRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultPhotoAnalysisDraftServiceTest {
+
+    @Mock
+    private PhotoAnalysisDraftRepository repository;
+
+    @Mock
+    private NutritionHistoryService nutritionHistoryService;
+
+    private DefaultPhotoAnalysisDraftService service;
+
+    @BeforeEach
+    void setUp() {
+        this.service = new DefaultPhotoAnalysisDraftService(repository, nutritionHistoryService, new ObjectMapper());
+    }
+
+    @Test
+    void createStoresDraftWithoutWritingFinalNutritionEntry() {
+        UUID userId = UUID.randomUUID();
+        LocalDate date = LocalDate.of(2026, 4, 6);
+        PhotoAnalysisResponse analysis = sampleAnalysis();
+
+        when(repository.save(any(PhotoAnalysisDraftEntity.class))).thenAnswer(invocation -> {
+            PhotoAnalysisDraftEntity e = invocation.getArgument(0);
+            e.setId(UUID.randomUUID());
+            return e;
+        });
+
+        var response = service.create(new CreatePhotoAnalysisDraftRequest(userId, date, analysis));
+
+        assertThat(response.id()).isNotNull();
+        assertThat(response.userId()).isEqualTo(userId);
+        assertThat(response.status()).isEqualTo(PhotoAnalysisDraftStatus.DRAFT);
+        assertThat(response.analysis().totals().calories()).isEqualByComparingTo("560");
+        verify(nutritionHistoryService, never()).upsert(any());
+    }
+
+    @Test
+    void confirmWritesFinalNutritionEntryAndMarksDraftConfirmed() {
+        UUID draftId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        LocalDate date = LocalDate.of(2026, 4, 6);
+
+        PhotoAnalysisDraftEntity entity = new PhotoAnalysisDraftEntity();
+        entity.setId(draftId);
+        entity.setUserId(userId);
+        entity.setEntryDate(date);
+        entity.setStatus(PhotoAnalysisDraftStatus.DRAFT);
+        entity.setEstimatedCaloriesKcal(new BigDecimal("560"));
+        entity.setEstimatedProteinG(new BigDecimal("30"));
+        entity.setEstimatedFiberG(new BigDecimal("8"));
+        entity.setAnalysisJson(new ObjectMapper().valueToTree(sampleAnalysis()).toString());
+
+        when(repository.findById(draftId)).thenReturn(Optional.of(entity));
+        when(repository.save(any(PhotoAnalysisDraftEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        DailyNutritionEntrySnapshot snapshot = new DailyNutritionEntrySnapshot(
+                UUID.randomUUID(),
+                userId,
+                date,
+                null,
+                new BigDecimal("570"),
+                null,
+                new BigDecimal("31"),
+                new BigDecimal("7"),
+                "confirmed",
+                null,
+                null
+        );
+        when(nutritionHistoryService.upsert(any())).thenReturn(snapshot);
+
+        var response = service.confirm(draftId, new ConfirmPhotoAnalysisDraftRequest(
+                new BigDecimal("570"),
+                new BigDecimal("31"),
+                new BigDecimal("7"),
+                "confirmed"
+        ));
+
+        assertThat(response.status()).isEqualTo(PhotoAnalysisDraftStatus.CONFIRMED);
+        assertThat(response.confirmedDailyEntryId()).isEqualTo(snapshot.id());
+        assertThat(response.estimatedCaloriesKcal()).isEqualByComparingTo("570");
+        verify(nutritionHistoryService).upsert(any());
+    }
+
+    @Test
+    void confirmFailsForAlreadyConfirmedDraft() {
+        UUID draftId = UUID.randomUUID();
+        PhotoAnalysisDraftEntity entity = new PhotoAnalysisDraftEntity();
+        entity.setId(draftId);
+        entity.setStatus(PhotoAnalysisDraftStatus.CONFIRMED);
+        entity.setAnalysisJson(new ObjectMapper().valueToTree(sampleAnalysis()).toString());
+
+        when(repository.findById(draftId)).thenReturn(Optional.of(entity));
+
+        assertThatThrownBy(() -> service.confirm(draftId, new ConfirmPhotoAnalysisDraftRequest(null, null, null, null)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("409 CONFLICT");
+    }
+
+    private static PhotoAnalysisResponse sampleAnalysis() {
+        return new PhotoAnalysisResponse(
+                List.of(new AnalyzedFoodItem(
+                        "salad",
+                        "250 g",
+                        new BigDecimal("560"),
+                        new BigDecimal("30"),
+                        new BigDecimal("8"),
+                        new BigDecimal("22"),
+                        new BigDecimal("50"),
+                        new BigDecimal("0.79")
+                )),
+                new PhotoAnalysisTotals(
+                        new BigDecimal("560"),
+                        new BigDecimal("30"),
+                        new BigDecimal("8"),
+                        new BigDecimal("22"),
+                        new BigDecimal("50")
+                ),
+                new BigDecimal("0.79"),
+                List.of("ai suggestion"),
+                true
+        );
+    }
+}


### PR DESCRIPTION
## Context
Backend photo analysis currently returns AI output directly, but we need draft/confirm semantics so AI remains suggestion-only until user confirmation.

## Changes
- added Flyway migration `V3__photo_analysis_drafts.sql` with dedicated `photo_analysis_drafts` table and status/indexes
- implemented draft domain slice:
  - entity + status enum + repository
  - service for create/get/confirm
  - controller endpoints:
    - `POST /api/photo-analysis/drafts`
    - `GET /api/photo-analysis/drafts/{draftId}`
    - `POST /api/photo-analysis/drafts/{draftId}/confirm`
- confirm flow writes to final nutrition history only during confirm (via `NutritionHistoryService.upsert`)
- create/get flow persists and returns draft suggestions without writing final nutrition truth
- added tests for draft lifecycle and controller coverage

## How it was tested
- `mvn test` in `backend/`

Addresses issue #37