### PR TITLE
Redesign home screen with dark calorie dashboard

### DIFF
--- a/frontend/src/features/current-day/components/CurrentDayTab.tsx
+++ b/frontend/src/features/current-day/components/CurrentDayTab.tsx
@@ -73,13 +73,7 @@ export function CurrentDayTab({ refreshToken = 0, successMessage = '', onDayUpda
   }
 
   return (
-    <section className="screen-section">
-      <header className="screen-header">
-        <div>
-          {summary ? <p className="screen-header__meta">Дата: {summary.dateLabel}</p> : null}
-        </div>
-      </header>
-
+    <section className="screen-section screen-section--home-dark">
       {successMessage ? <section className="panel detail-panel"><p className="success-text">{successMessage}</p></section> : null}
       {loading ? <section className="panel detail-panel"><p>Загружаем сводку...</p></section> : null}
       {!loading && error ? <section className="panel detail-panel"><p className="error-text">{error}</p></section> : null}
@@ -87,27 +81,25 @@ export function CurrentDayTab({ refreshToken = 0, successMessage = '', onDayUpda
       {!loading && !error && summary ? <TodaySummaryBlock summary={summary} /> : null}
 
       {!loading && summary ? (
-        <section className="panel detail-panel weight-panel weight-panel--compact">
-          <div className="weight-panel__content">
-            <div>
-              <p className="screen-header__meta">Вес сегодня</p>
-              <h3>{summary.weightKg == null ? 'Добавить вес' : `${summary.weightKg.toFixed(1)} кг`}</h3>
-            </div>
-            <div className="weight-panel__form">
-              <label>
-                Вес, кг
-                <input
-                  type="text"
-                  inputMode="decimal"
-                  value={weightInput}
-                  onChange={(event) => setWeightInput(event.target.value)}
-                  placeholder="Например, 82,4"
-                />
-              </label>
-              <button type="button" onClick={handleWeightSave} disabled={savingWeight}>
-                {savingWeight ? 'Сохраняем...' : 'Сохранить'}
-              </button>
-            </div>
+        <section className="weight-inline-card panel">
+          <div>
+            <p className="screen-header__meta">Weight</p>
+            <h3>{summary.weightKg == null ? 'Add today weight' : `${summary.weightKg.toFixed(1)} kg`}</h3>
+          </div>
+          <div className="weight-panel__form">
+            <label>
+              Weight, kg
+              <input
+                type="text"
+                inputMode="decimal"
+                value={weightInput}
+                onChange={(event) => setWeightInput(event.target.value)}
+                placeholder="82.4"
+              />
+            </label>
+            <button type="button" onClick={handleWeightSave} disabled={savingWeight}>
+              {savingWeight ? 'Saving...' : 'Save'}
+            </button>
           </div>
         </section>
       ) : null}

--- a/frontend/src/features/current-day/components/TodaySummaryBlock.tsx
+++ b/frontend/src/features/current-day/components/TodaySummaryBlock.tsx
@@ -4,16 +4,23 @@ interface MacroCardProps {
   label: string
   value: number
   unit: string
+  progress: number
+  tone: 'purple' | 'orange' | 'pink'
 }
 
-function MacroCard({ label, value, unit }: MacroCardProps) {
+function MacroCard({ label, value, unit, progress, tone }: MacroCardProps) {
   return (
-    <article className="summary-card summary-card--macro">
-      <span className="summary-card__label">{label}</span>
-      <strong className="summary-card__value">
-        {Math.round(value)}
-        <span className="summary-card__unit"> {unit}</span>
-      </strong>
+    <article className="macro-meter-card">
+      <div className="macro-meter-card__header">
+        <span>{label}</span>
+        <strong>
+          {Math.round(value)}
+          <span>{unit}</span>
+        </strong>
+      </div>
+      <div className="macro-meter-card__track">
+        <span className={`macro-meter-card__fill macro-meter-card__fill--${tone}`} style={{ width: `${progress}%` }} />
+      </div>
     </article>
   )
 }
@@ -23,28 +30,76 @@ interface TodaySummaryBlockProps {
 }
 
 export function TodaySummaryBlock({ summary }: TodaySummaryBlockProps) {
+  const consumed = Math.round(summary.consumedCalories)
+  const target = Math.max(1, Math.round(summary.dailyTargetCalories))
+  const remaining = Math.round(summary.remainingCalories)
+  const ringProgress = Math.min(100, Math.max(0, Math.round((consumed / target) * 100)))
+  const circumference = 2 * Math.PI * 64
+  const dashOffset = circumference - (circumference * ringProgress) / 100
+
   return (
-    <section className="today-summary" aria-label="Сводка питания за день">
-      <article className="summary-card summary-card--hero summary-card--accent">
-        <div>
-          <span className="summary-card__label">Осталось сегодня</span>
-          <strong className="summary-card__value summary-card__value--hero">
-            {Math.round(summary.remainingCalories)}
-            <span className="summary-card__unit"> ккал</span>
-          </strong>
-          <p className="subtle-text">Съедено {Math.round(summary.consumedCalories)} из {Math.round(summary.dailyTargetCalories)}</p>
+    <section className="today-summary today-summary--dark" aria-label="Сводка питания за день">
+      <article className="today-dark-card">
+        <div className="today-dark-card__topbar">
+          <button type="button" className="today-dark-card__back" aria-label="Назад">
+            ‹
+          </button>
+          <div>
+            <p className="today-dark-card__title">Calories Details</p>
+          </div>
+          <div className="today-dark-card__spacer" />
         </div>
-        <div className="summary-card__meta-badge">
-          <span>Цель</span>
-          <strong>{Math.round(summary.dailyTargetCalories)}</strong>
+
+        <div className="today-dark-ring-layout">
+          <div className="today-side-stat">
+            <strong>{consumed}</strong>
+            <span>EATEN</span>
+          </div>
+
+          <div className="today-ring">
+            <svg viewBox="0 0 160 160" className="today-ring__svg" aria-hidden="true">
+              <circle cx="80" cy="80" r="64" className="today-ring__track" />
+              <circle
+                cx="80"
+                cy="80"
+                r="64"
+                className="today-ring__progress"
+                strokeDasharray={circumference}
+                strokeDashoffset={dashOffset}
+              />
+            </svg>
+            <div className="today-ring__center">
+              <strong>{remaining}</strong>
+              <span>kcal left</span>
+            </div>
+          </div>
+
+          <div className="today-side-stat">
+            <strong>{target}</strong>
+            <span>TARGET</span>
+          </div>
+        </div>
+
+        <div className="today-dark-card__cta-row">
+          <button type="button" className="today-dark-card__cta">See stats</button>
+        </div>
+
+        <div className="macro-meter-grid">
+          <MacroCard label="Protein" value={summary.proteinGrams} unit="g" progress={Math.min(100, Math.round((summary.proteinGrams / 180) * 100))} tone="purple" />
+          <MacroCard label="Fat" value={summary.fatGrams} unit="g" progress={Math.min(100, Math.round((summary.fatGrams / 90) * 100))} tone="orange" />
+          <MacroCard label="Fiber" value={summary.fiberGrams} unit="g" progress={Math.min(100, Math.round((summary.fiberGrams / 35) * 100))} tone="pink" />
+        </div>
+
+        <div className="today-insight-card">
+          <div className="today-insight-card__emoji">⚡</div>
+          <h3>Today insight</h3>
+          <p>
+            {summary.weightKg == null
+              ? 'Add your weight to keep the daily timeline complete.'
+              : `Weight logged: ${summary.weightKg.toFixed(1)} kg. Keep going.`}
+          </p>
         </div>
       </article>
-
-      <div className="current-day-grid current-day-grid--macros">
-        <MacroCard label="Белки" value={summary.proteinGrams} unit="г" />
-        <MacroCard label="Жиры" value={summary.fatGrams} unit="г" />
-        <MacroCard label="Клетчатка" value={summary.fiberGrams} unit="г" />
-      </div>
     </section>
   )
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -189,6 +189,244 @@ ul {
   gap: 16px;
 }
 
+.today-summary--dark {
+  gap: 20px;
+}
+
+.screen-section--home-dark {
+  gap: 16px;
+}
+
+.today-dark-card {
+  background: #101114;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 32px;
+  padding: 22px;
+  color: #ffffff;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.34);
+}
+
+.today-dark-card__topbar {
+  display: grid;
+  grid-template-columns: 48px 1fr 48px;
+  align-items: center;
+  margin-bottom: 18px;
+}
+
+.today-dark-card__back,
+.today-dark-card__spacer {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+}
+
+.today-dark-card__back {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: #ffffff;
+  cursor: default;
+}
+
+.today-dark-card__spacer {
+  display: block;
+}
+
+.today-dark-card__title {
+  text-align: center;
+  font-size: 1.45rem;
+  font-weight: 800;
+  color: #ffffff;
+}
+
+.today-dark-ring-layout {
+  display: grid;
+  grid-template-columns: minmax(72px, 1fr) 220px minmax(72px, 1fr);
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.today-side-stat {
+  text-align: center;
+}
+
+.today-side-stat strong {
+  display: block;
+  font-size: 2rem;
+  line-height: 1;
+  color: #ffffff;
+}
+
+.today-side-stat span {
+  display: block;
+  margin-top: 6px;
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  color: rgba(255, 255, 255, 0.56);
+}
+
+.today-ring {
+  position: relative;
+  width: 220px;
+  height: 220px;
+  margin: 0 auto;
+}
+
+.today-ring__svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.today-ring__track,
+.today-ring__progress {
+  fill: none;
+  stroke-width: 18;
+}
+
+.today-ring__track {
+  stroke: #1d2230;
+}
+
+.today-ring__progress {
+  stroke: #ffbf3f;
+  stroke-linecap: round;
+}
+
+.today-ring__center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.today-ring__center strong {
+  font-size: 3.5rem;
+  line-height: 1;
+  color: #ffffff;
+}
+
+.today-ring__center span {
+  margin-top: 8px;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.66);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.today-dark-card__cta-row {
+  display: flex;
+  justify-content: center;
+  margin-top: 12px;
+}
+
+.today-dark-card__cta {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.06);
+  color: #ffffff;
+  border-radius: 999px;
+  padding: 12px 18px;
+  font-weight: 700;
+}
+
+.macro-meter-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.macro-meter-card {
+  border-radius: 20px;
+  padding: 16px;
+  background: #17191f;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.macro-meter-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: end;
+  color: #ffffff;
+}
+
+.macro-meter-card__header span {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.74);
+}
+
+.macro-meter-card__header strong {
+  font-size: 1rem;
+  color: #ffffff;
+}
+
+.macro-meter-card__header strong span {
+  margin-left: 4px;
+  font-size: 0.82rem;
+}
+
+.macro-meter-card__track {
+  margin-top: 14px;
+  height: 7px;
+  border-radius: 999px;
+  background: #232734;
+  overflow: hidden;
+}
+
+.macro-meter-card__fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+}
+
+.macro-meter-card__fill--purple {
+  background: linear-gradient(90deg, #7c3aed 0%, #d946ef 100%);
+}
+
+.macro-meter-card__fill--orange {
+  background: linear-gradient(90deg, #fb923c 0%, #ef4444 100%);
+}
+
+.macro-meter-card__fill--pink {
+  background: linear-gradient(90deg, #ec4899 0%, #a855f7 100%);
+}
+
+.today-insight-card {
+  margin-top: 14px;
+  border-radius: 24px;
+  background: #17191f;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 24px 18px;
+  text-align: center;
+}
+
+.today-insight-card__emoji {
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.today-insight-card h3 {
+  margin-top: 12px;
+  font-size: 2rem;
+  color: #ffffff;
+}
+
+.today-insight-card p {
+  margin-top: 10px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.weight-inline-card {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
 .summary-card {
   padding: 22px;
   border-radius: 24px;
@@ -717,8 +955,15 @@ ul {
 
 @media (max-width: 900px) {
   .current-day-grid,
-  .statistics-grid {
+  .statistics-grid,
+  .macro-meter-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .today-dark-ring-layout,
+  .weight-inline-card {
+    grid-template-columns: 1fr;
+    flex-direction: column;
   }
 
   .summary-card--hero,
@@ -762,6 +1007,25 @@ ul {
 @media (max-width: 640px) {
   .app-shell {
     padding: 18px 14px 60px;
+  }
+
+  .today-dark-card {
+    padding: 18px;
+    border-radius: 26px;
+  }
+
+  .today-dark-ring-layout,
+  .macro-meter-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .today-ring {
+    width: 200px;
+    height: 200px;
+  }
+
+  .today-ring__center strong {
+    font-size: 3rem;
   }
 
   .tabs-header {


### PR DESCRIPTION
## Summary
- redesign the main Today screen in a dark premium mobile style based on the provided reference
- add a central calorie ring, side metrics, macro progress cards, and a dark insight card
- keep the screen wired to our current nutrition data and weight input flow

## Testing
- npm run build --prefix frontend