### PR TITLE
Match app shell to dark home screen

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -30,19 +30,19 @@ export default function App() {
 
   return (
     <main className="app-shell">
-      <header className="app-header app-header--compact">
+      <header className="app-header app-header--dark">
         <div>
-          <p className="app-header__eyebrow">Nutrition App v2</p>
+          <p className="app-header__eyebrow">Daily nutrition</p>
           <h1>Nutrition</h1>
         </div>
       </header>
 
-      <section className="tabs-shell">
-        <div className="tabs-header" role="tablist" aria-label="Разделы приложения">
+      <section className="tabs-shell tabs-shell--dark">
+        <div className="tabs-header tabs-header--dark" role="tablist" aria-label="Разделы приложения">
           <button
             type="button"
             role="tab"
-            className={`tab-button ${activeTab === tabs.currentDay ? 'tab-button--active' : ''}`}
+            className={`tab-button tab-button--dark ${activeTab === tabs.currentDay ? 'tab-button--active' : ''}`}
             aria-selected={activeTab === tabs.currentDay}
             onClick={() => setActiveTab(tabs.currentDay)}
           >
@@ -51,7 +51,7 @@ export default function App() {
           <button
             type="button"
             role="tab"
-            className={`tab-button ${activeTab === tabs.statistics ? 'tab-button--active' : ''}`}
+            className={`tab-button tab-button--dark ${activeTab === tabs.statistics ? 'tab-button--active' : ''}`}
             aria-selected={activeTab === tabs.statistics}
             onClick={() => setActiveTab(tabs.statistics)}
           >
@@ -60,7 +60,7 @@ export default function App() {
           <button
             type="button"
             role="tab"
-            className={`tab-button ${activeTab === tabs.photoAnalyzer ? 'tab-button--active' : ''}`}
+            className={`tab-button tab-button--dark ${activeTab === tabs.photoAnalyzer ? 'tab-button--active' : ''}`}
             aria-selected={activeTab === tabs.photoAnalyzer}
             onClick={() => setActiveTab(tabs.photoAnalyzer)}
           >
@@ -68,7 +68,7 @@ export default function App() {
           </button>
         </div>
 
-        <div className="tabs-body">
+        <div className="tabs-body tabs-body--dark">
           {activeTab === tabs.currentDay ? (
             <CurrentDayTab
               refreshToken={summaryRefreshToken}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -52,13 +52,17 @@ ul {
 }
 
 .app-shell {
-  width: min(1100px, 100%);
+  width: min(520px, 100%);
   margin: 0 auto;
-  padding: 28px 18px 72px;
+  padding: 18px 14px 32px;
 }
 
 .app-header {
   margin-bottom: 14px;
+}
+
+.app-header--dark {
+  padding-inline: 8px;
 }
 
 .app-header__eyebrow,
@@ -70,11 +74,19 @@ ul {
   color: #8d7b68;
 }
 
+.app-header--dark .app-header__eyebrow {
+  color: rgba(255, 255, 255, 0.54);
+}
+
 .app-header h1,
 .screen-header h2,
 .analyzer-panel h3,
 .final-entry-panel h3 {
   color: #14213d;
+}
+
+.app-header--dark h1 {
+  color: #ffffff;
 }
 
 .app-header h1 {
@@ -85,6 +97,10 @@ ul {
 .tabs-shell {
   display: grid;
   gap: 18px;
+}
+
+.tabs-shell--dark {
+  gap: 14px;
 }
 
 .tabs-header {
@@ -103,6 +119,15 @@ ul {
   top: 12px;
   z-index: 10;
   backdrop-filter: blur(16px);
+}
+
+.tabs-header--dark {
+  width: 100%;
+  justify-content: space-between;
+  background: #17191f;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.24);
+  padding: 8px;
 }
 
 .tabs-header::-webkit-scrollbar,
@@ -132,10 +157,21 @@ ul {
   font-weight: 700;
 }
 
+.tab-button--dark {
+  flex: 1 1 0;
+  color: rgba(255, 255, 255, 0.58);
+}
+
 .tab-button--active {
   background: #1f2a44;
   color: #fff9f2;
   box-shadow: 0 10px 20px rgba(31, 42, 68, 0.18);
+}
+
+.tabs-header--dark .tab-button--active {
+  background: #2b2f38;
+  color: #ffffff;
+  box-shadow: none;
 }
 
 .tabs-body,
@@ -143,6 +179,10 @@ ul {
 .today-summary {
   display: grid;
   gap: 18px;
+}
+
+.tabs-body--dark {
+  gap: 14px;
 }
 
 .panel {


### PR DESCRIPTION
## Summary
- bring the surrounding app shell in line with the merged dark home screen
- update the header, outer layout, and tab bar to match the new dark treatment
- keep the new home screen from feeling visually disconnected from the rest of the app

## Testing
- npm run build --prefix frontend