### PR TITLE
Redesign statistics tab with dark insight cards

### DIFF
--- a/frontend/src/features/statistics/components/StatisticsTab.tsx
+++ b/frontend/src/features/statistics/components/StatisticsTab.tsx
@@ -50,27 +50,27 @@ function formatMetricValue(value: number | null | undefined, digits = 2): string
 
 function SummaryCard({ title, summary }: { title: string; summary: NutritionBalanceSummary }) {
   return (
-    <section className="summary-card summary-card--stats">
-      <span className="summary-card__label">{title}</span>
-      <strong className={`summary-card__value ${summary.calorieBalance > 0 ? 'text-over' : 'text-under'}`}>
-        {formatSigned(summary.calorieBalance)}
-        <span className="summary-card__unit"> ккал</span>
-      </strong>
-      <p className="subtle-text">
-        Съедено {summary.consumedCalories} из {summary.targetCalories}
-      </p>
+    <section className="stats-metric-card">
+      <div className="stats-metric-card__top">
+        <span>{title}</span>
+        <span className={`stats-metric-card__delta ${summary.calorieBalance > 0 ? 'text-over' : 'text-under'}`}>
+          {formatSigned(summary.calorieBalance)} ккал
+        </span>
+      </div>
+      <strong>{summary.consumedCalories}</strong>
+      <p>из {summary.targetCalories} kcal target</p>
     </section>
   )
 }
 
 function WeightAverageCard({ title, value }: { title: string; value: number | null }) {
   return (
-    <section className="summary-card summary-card--stats">
-      <span className="summary-card__label">{title}</span>
-      <strong className="summary-card__value">
-        {value == null ? '—' : value.toFixed(1)}
-        <span className="summary-card__unit"> кг</span>
-      </strong>
+    <section className="stats-metric-card">
+      <div className="stats-metric-card__top">
+        <span>{title}</span>
+      </div>
+      <strong>{value == null ? '—' : value.toFixed(1)}</strong>
+      <p>kg average</p>
     </section>
   )
 }
@@ -187,7 +187,7 @@ function LineChart({
   return (
     <>
       <section
-        className={`panel statistics-panel ${onExpand ? 'statistics-panel--interactive' : ''}`}
+        className={`panel statistics-panel statistics-panel--dark ${onExpand ? 'statistics-panel--interactive' : ''}`}
         onClick={onExpand}
         role={onExpand ? 'button' : undefined}
         tabIndex={onExpand ? 0 : undefined}
@@ -200,7 +200,7 @@ function LineChart({
       >
         <div className="statistics-panel__header">
           <div>
-            <p className="screen-header__eyebrow">Статистика</p>
+            <p className="screen-header__eyebrow">Metric</p>
             <h3>{title}</h3>
           </div>
           <div className="statistics-panel__actions">
@@ -210,7 +210,7 @@ function LineChart({
                 event.stopPropagation()
                 onExpand()
               }}>
-                Развернуть
+                Expand
               </button>
             ) : null}
           </div>
@@ -236,11 +236,11 @@ function StatisticsTable({ points }: { points: NutritionStatisticsPoint[] }) {
   const orderedPoints = [...points].reverse()
 
   return (
-    <section className="panel statistics-panel">
+    <section className="panel statistics-panel statistics-panel--dark">
       <div className="statistics-panel__header">
         <div>
-          <p className="screen-header__eyebrow">Отклонения</p>
-          <h3>Дневные значения</h3>
+          <p className="screen-header__eyebrow">History</p>
+          <h3>Daily values</h3>
         </div>
       </div>
 
@@ -316,14 +316,14 @@ export function StatisticsTab({ refreshToken = 0 }: StatisticsTabProps) {
   const selectedTitle = rangeDays === 30 ? 'месяц' : `${rangeDays} дней`
 
   return (
-    <section className="screen-section">
-      <header className="screen-header">
+    <section className="screen-section screen-section--statistics-dark">
+      <header className="screen-header screen-header--statistics-dark">
         <div>
-          <p className="screen-header__eyebrow">Статистика</p>
-          <h2>История питания</h2>
+          <p className="screen-header__eyebrow">Analytics</p>
+          <h2>Nutrition trends</h2>
         </div>
         <div className="statistics-toolbar">
-          <p className="screen-header__meta">Дневные, недельные и месячные отклонения.</p>
+          <p className="screen-header__meta">Your weight and intake history in a darker insights view.</p>
           <RangeSelector value={rangeDays} onChange={setRangeDays} />
         </div>
       </header>
@@ -332,7 +332,7 @@ export function StatisticsTab({ refreshToken = 0 }: StatisticsTabProps) {
       {!loading && error ? <section className="panel detail-panel"><p className="error-text">{error}</p></section> : null}
       {!loading && !error && data ? (
         <>
-          <section className="current-day-grid">
+          <section className="stats-metric-grid">
             <SummaryCard
               title={`Отклонение за ${selectedTitle}`}
               summary={rangeDays === 30 ? data.monthlySummary : data.selectedPeriodSummary}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -669,10 +669,63 @@ ul {
   gap: 18px;
 }
 
+.stats-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.stats-metric-card {
+  background: #17191f;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 22px;
+  padding: 16px;
+  color: #ffffff;
+}
+
+.stats-metric-card__top {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: start;
+}
+
+.stats-metric-card__top > span:first-child,
+.stats-metric-card p {
+  color: rgba(255, 255, 255, 0.62);
+}
+
+.stats-metric-card strong {
+  display: block;
+  margin-top: 18px;
+  font-size: 2rem;
+  line-height: 1;
+  color: #ffffff;
+}
+
+.stats-metric-card__delta {
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
 .statistics-toolbar {
   display: grid;
   gap: 10px;
   justify-items: end;
+}
+
+.screen-section--statistics-dark .screen-header__eyebrow,
+.screen-section--statistics-dark .screen-header__meta,
+.screen-section--statistics-dark .subtle-text,
+.screen-section--statistics-dark h2,
+.screen-section--statistics-dark h3,
+.screen-section--statistics-dark .statistics-table__head,
+.screen-section--statistics-dark .statistics-table__row {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.screen-header--statistics-dark {
+  align-items: start;
 }
 
 .range-selector {
@@ -685,6 +738,20 @@ ul {
   max-width: 100%;
   overflow-x: auto;
   scrollbar-width: none;
+}
+
+.screen-section--statistics-dark .range-selector {
+  background: #17191f;
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+.screen-section--statistics-dark .range-selector__button {
+  color: rgba(255, 255, 255, 0.58);
+}
+
+.screen-section--statistics-dark .range-selector__button--active {
+  background: #2b2f38;
+  color: #ffffff;
 }
 
 .range-selector__button {
@@ -708,8 +775,14 @@ ul {
   cursor: pointer;
 }
 
+.statistics-panel--dark {
+  background: #17191f;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.28);
+}
+
 .statistics-panel--interactive:hover {
-  box-shadow: 0 24px 56px rgba(89, 72, 54, 0.12);
+  box-shadow: 0 24px 56px rgba(0, 0, 0, 0.34);
 }
 
 .statistics-panel--interactive:focus-visible {
@@ -786,6 +859,15 @@ ul {
   border-top: 1px dashed #dbcbb9;
 }
 
+.statistics-panel--dark .line-chart__grid span {
+  border-top-color: rgba(255, 255, 255, 0.08);
+}
+
+.statistics-panel--dark .line-chart__guides,
+.statistics-panel--dark .line-chart__labels {
+  color: rgba(255, 255, 255, 0.48);
+}
+
 .line-chart__guides,
 .line-chart__labels {
   color: #8c7866;
@@ -838,6 +920,10 @@ ul {
   stroke: #6b5b4b;
   stroke-dasharray: 10 8;
   opacity: 0.55;
+}
+
+.statistics-panel--dark .line-chart__path--target {
+  stroke: rgba(255, 255, 255, 0.42);
 }
 
 .line-chart__labels {
@@ -1025,7 +1111,8 @@ ul {
 @media (max-width: 900px) {
   .current-day-grid,
   .statistics-grid,
-  .macro-meter-grid {
+  .macro-meter-grid,
+  .stats-metric-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -1114,7 +1201,8 @@ ul {
 
   .current-day-grid,
   .draft-item-card__grid,
-  .draft-item-card__header {
+  .draft-item-card__header,
+  .stats-metric-grid {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- redesign the Statistics tab in a dark card-based style based on the provided references
- keep the current nutrition data and chart logic while updating the containers, metric cards, and controls
- make the tab visually match the new dark home screen direction

## Testing
- npm run build --prefix frontend